### PR TITLE
use angular's location service

### DIFF
--- a/app/manage/pods/device-details/share-modal-directive/index.js
+++ b/app/manage/pods/device-details/share-modal-directive/index.js
@@ -11,10 +11,12 @@ module.exports = [
       controller: [
         '$scope',
         '$timeout',
-        function($scope, $timeout) {
+        '$location',
+        function($scope, $timeout, $location) {
+
           // template variables -------------------
           $scope.copySuccess = false;
-          $scope.url = window.location.hostname + window.location.pathname;
+          $scope.url = $location.absUrl().replace('?demo=1', '');
 
           // create clipboard ---------------------
           var clipboard = new Clipboard('.copy-btn');


### PR DESCRIPTION
For the share modal, the url wasn't getting set properly because angular is the worst and needs to use it's own location service to parse it's url correctly. 

:-1: :stuck_out_tongue_closed_eyes: 