### PR TITLE
fix rules to show save button

### DIFF
--- a/app/manage/assets/css/form.scss
+++ b/app/manage/assets/css/form.scss
@@ -1,8 +1,8 @@
 /* Forms ------------------*/
 fieldset {
   border: none;
-  margin-left: 0;
-  padding-left: 0;
+  margin: 0;
+  padding: 0;
   &[disabled] {
     input[type='text'] {
       color: #777;
@@ -17,6 +17,7 @@ fieldset {
 .form-row {
   color: #3D3D3D;
   padding-bottom: 5px;
+  padding: 5px 0;
   label {
     display: block;
     font-size: 13px;

--- a/app/manage/pods/rules-form/assets/css/style.scss
+++ b/app/manage/pods/rules-form/assets/css/style.scss
@@ -63,7 +63,11 @@
     font-size: 13px;
     font-weight: 500;
   }
+  .button {
+    min-width: 73px;
+  }
 }
+
 .condition-list {
   li {
     color: #D1D1D1;

--- a/app/manage/pods/rules-form/conditional-form-directive/index.js
+++ b/app/manage/pods/rules-form/conditional-form-directive/index.js
@@ -17,6 +17,7 @@ module.exports = [
       },
       link: function(scope, elm, attrs) {
         scope.disableForm = true;
+        scope.editting = false;
         if (!scope.rule) {
           scope.rule = {
             'topic': 'sensor',
@@ -27,7 +28,9 @@ module.exports = [
         }
 
         scope.editCondition = function() {
-          scope.editMode = true;
+          scope.editMode = !scope.editMode;
+          scope.editting = !scope.editting;
+          scope.listMode = !scope.listMode;
         };
 
         scope.deleteCondition = function(index, parentIndex) {

--- a/app/manage/pods/rules-form/conditional-form-directive/template.tmpl
+++ b/app/manage/pods/rules-form/conditional-form-directive/template.tmpl
@@ -48,7 +48,7 @@
         <i class="fa fa-times" ng-click='deleteCondition(index)'></i>
       </span>
       <!--edit mode -->
-      <button class='button secondary' ng-if="!listMode && editting" ng-click='editCondition()'>+ Save </button>
+      <button class='button secondary' ng-if="!listMode && editting" ng-click='editCondition()'>Update</button>
       <!-- new mode -->
       <button class='button secondary' ng-if="!listMode && !editting" ng-click='callUpdate()'>+ Add</button>
     </div>

--- a/app/manage/pods/rules-form/conditional-form-directive/template.tmpl
+++ b/app/manage/pods/rules-form/conditional-form-directive/template.tmpl
@@ -47,8 +47,10 @@
         <i class="fa fa-pencil" ng-click='editCondition()'></i>
         <i class="fa fa-times" ng-click='deleteCondition(index)'></i>
       </span>
+      <!--edit mode -->
+      <button class='button secondary' ng-if="!listMode && editting" ng-click='editCondition()'>+ Save </button>
       <!-- new mode -->
-      <button class='button secondary' ng-if="!listMode" ng-click='callUpdate()'>+ Add</button>
+      <button class='button secondary' ng-if="!listMode && !editting" ng-click='callUpdate()'>+ Add</button>
     </div>
   </fieldset>
 </div>


### PR DESCRIPTION
The problem was that when editing the rules the save button didn't show up (??) 
I don't see anything in the log to suggest we had this functionality.  If you edit and then hit the form's save button, it'll save all the changes you make.

The only call to the server is done when pushing the save button for the entire form.

TEST HERE: https://warm-reaches-23967.herokuapp.com/manage/#/rules-form/1

![coolrule](https://cloud.githubusercontent.com/assets/607541/12994636/f41bdbb2-d0d6-11e5-9952-e33bf29dcc70.gif)
