### PR TITLE
add more channels to provisioning

### DIFF
--- a/provision/index.js
+++ b/provision/index.js
@@ -66,6 +66,48 @@ bp.getEnv(process.env)
       body.name = 'device-log';
       body.persistenceType = 'timeSeries';
     },
+    function(body, $) {
+      body.entityId = $.deviceTemplate.id;
+      body.entityType = 'deviceTemplate';
+      body.name = 'temp';
+      body.persistenceType = 'timeSeries';
+    },
+    function(body, $) {
+      body.entityId = $.deviceTemplate.id;
+      body.entityType = 'deviceTemplate';
+      body.name = 'humidity';
+      body.persistenceType = 'timeSeries';
+    },
+    function(body, $) {
+      body.entityId = $.deviceTemplate.id;
+      body.entityType = 'deviceTemplate';
+      body.name = 'no2';
+      body.persistenceType = 'timeSeries';
+    },
+    function(body, $) {
+      body.entityId = $.deviceTemplate.id;
+      body.entityType = 'deviceTemplate';
+      body.name = 'co';
+      body.persistenceType = 'timeSeries';
+    },
+    function(body, $) {
+      body.entityId = $.deviceTemplate.id;
+      body.entityType = 'deviceTemplate';
+      body.name = 'dust';
+      body.persistenceType = 'timeSeries';
+    },
+    function(body, $) {
+      body.entityId = $.deviceTemplate.id;
+      body.entityType = 'deviceTemplate';
+      body.name = 'filter';
+      body.persistenceType = 'timeSeries';
+    },
+    function(body, $) {
+      body.entityId = $.deviceTemplate.id;
+      body.entityType = 'deviceTemplate';
+      body.name = 'fan';
+      body.persistenceType = 'timeSeries';
+    }
   ]))
 
   .then(bp.createOrganizationTemplate(function(body, $) {

--- a/provision/index.js
+++ b/provision/index.js
@@ -81,12 +81,6 @@ bp.getEnv(process.env)
     function(body, $) {
       body.entityId = $.deviceTemplate.id;
       body.entityType = 'deviceTemplate';
-      body.name = 'no2';
-      body.persistenceType = 'timeSeries';
-    },
-    function(body, $) {
-      body.entityId = $.deviceTemplate.id;
-      body.entityType = 'deviceTemplate';
       body.name = 'co';
       body.persistenceType = 'timeSeries';
     },
@@ -106,7 +100,7 @@ bp.getEnv(process.env)
       body.entityId = $.deviceTemplate.id;
       body.entityType = 'deviceTemplate';
       body.name = 'fan';
-      body.persistenceType = 'timeSeries';
+      body.persistenceType = 'simple';
     }
   ]))
 


### PR DESCRIPTION
To test locally run `npm run local-provision`

In your terminal you'll see 
```
API channelsTemplates.create 1/10
API channelsTemplates.create 2/10
API channelsTemplates.create 3/10
API channelsTemplates.create 4/10
API channelsTemplates.create 5/10
API channelsTemplates.create 6/10
API channelsTemplates.create 7/10
API channelsTemplates.create 8/10
API channelsTemplates.create 9/10
API channelsTemplates.create 10/10
```

there are now 10 channels!! 

1. temp
2. humidity
3. no2
4.  co
5. dust
6. filter
7.  fan
8. sensor
9. control 
10. device-log

Sensor is still there until we convert everything to use the channels instead of the labels on the sensor channel 