### PR TITLE
refactor(config): default orchestrator to false

### DIFF
--- a/app.json
+++ b/app.json
@@ -31,6 +31,11 @@
     "SALESFORCE_TOKEN": {
       "description": "Your Salesforce token",
       "required": false
+    },
+    "HABANERO_EMBEDDED": {
+      "description": "Use habanero orchestrator rules engine",
+      "required": false,
+      "value": "false"
     }
   }
 }


### PR DESCRIPTION
Multiple people have said that we are not ready to default Concaria to use the orchestrator as a rules engine, so for now, we'd like it to default to false, and enable it as needed